### PR TITLE
Library refactor

### DIFF
--- a/src/brownie.cpp
+++ b/src/brownie.cpp
@@ -53,7 +53,7 @@ void Brownie::printInFile()
 void Brownie::parameterEstimationInStage4(DBGraph &graph){
         cout <<endl<< " ================ Parameter Estimation ===============" << endl;
         double  estimatedKmerCoverage=0,estimatedMKmerCoverageSTD=0, cutOffvalue=0, readLength=0;
-        readLength=libraries.getReadLength();
+        readLength=libraries.getAvgReadLength();
         if (readLength<=settings.getK() ||readLength>500)
                 readLength=150;
 

--- a/src/bubble.cpp
+++ b/src/bubble.cpp
@@ -1,8 +1,3 @@
-#include "graph.h"
-
-#include "library.h"
-
-
 /***************************************************************************
  *   Copyright (C) 2014, 2015 Jan Fostier (jan.fostier@intec.ugent.be)     *
  *   Copyright (C) 2014, 2015 Mahdi Heydari (mahdi.heydari@intec.ugent.be) *
@@ -25,6 +20,8 @@
  ***************************************************************************/
 
 #include "graph.h"
+
+#include <queue>
 
 using namespace std;
 class PathInfo {

--- a/src/coverage.cpp
+++ b/src/coverage.cpp
@@ -658,7 +658,7 @@ double DBGraph::getInitialEstimateForCoverage ( const ReadLibrary& input,
         DBGraph::graph = this;
         sort ( sortedNodes.begin(), sortedNodes.end(), sortByLength );
 
-        size_t RL = input.getReadLength();
+        size_t RL = input.getAvgReadLength();
         size_t k = Kmer::getK();
 
         // for the biggest nodes compute the coverage
@@ -680,7 +680,7 @@ double DBGraph::estimateReadStartCoverage ( const ReadLibrary &input,
 {
         size_t nom = 0, denom = 0;
         size_t k = Kmer::getK();
-        size_t RL = input.getReadLength();
+        size_t RL = input.getAvgReadLength();
 
         for ( NodeID id = 1; id <= numNodes; id++ ) {
                 DSNode& node = getDSNode ( id );

--- a/src/global.h
+++ b/src/global.h
@@ -70,6 +70,10 @@ typedef uint32_t KmerLSB;       // set to uint16_t and all hell will break loose
 
 #define SCAFFOLD_SNAP_LINK 5
 
+// The number of recordBlocks simulataneously held in memory. Higher values
+// result in more parallel chunks at the cost of increased memory use.
+#define NUM_RECORD_BLOCKS 2
+
 // ============================================================================
 // TYPEDEFS
 // ============================================================================

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -261,7 +261,7 @@ bool LibraryContainer::getRecordChunk(vector<ReadRecord>& buffer,
                 workLock.unlock();
 
                 // send a termination message to the output thread
-                std::unique_lock<std::mutex> outputLock(inputMutex);
+                std::unique_lock<std::mutex> outputLock(outputMutex);
                 outputBlocks[currWorkBlockID] = NULL;
                 outputLock.unlock();
 
@@ -286,8 +286,8 @@ bool LibraryContainer::getRecordChunk(vector<ReadRecord>& buffer,
 
         // D.b) if no output thread is active, return block to input queue
         if (moveToNextBlock && !outputThreadActive) {
-                std::unique_lock<std::mutex> inputLock(inputMutex);
                 block->reset();
+                std::unique_lock<std::mutex> inputLock(inputMutex);
                 inputBlocks.push_back(block);
                 inputReady.notify_one();
                 inputLock.unlock();
@@ -316,7 +316,7 @@ bool LibraryContainer::getReadChunk(vector<string>& buffer,
                 workLock.unlock();
 
                 // send a termination message to the output thread
-                std::unique_lock<std::mutex> outputLock(inputMutex);
+                std::unique_lock<std::mutex> outputLock(outputMutex);
                 outputBlocks[currWorkBlockID] = NULL;
                 outputLock.unlock();
 
@@ -341,8 +341,8 @@ bool LibraryContainer::getReadChunk(vector<string>& buffer,
 
         // D.b) if no output thread is active, return block to input queue
         if (moveToNextBlock && !outputThreadActive) {
-                std::unique_lock<std::mutex> inputLock(inputMutex);
                 block->reset();
+                std::unique_lock<std::mutex> inputLock(inputMutex);
                 inputBlocks.push_back(block);
                 inputReady.notify_one();
                 inputLock.unlock();

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -1,6 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2014, 2015 Jan Fostier (jan.fostier@intec.ugent.be)     *
- *   Copyright (C) 2014, 2015 Mahdi Heydari (mahdi.heydari@intec.ugent.be) *
+ *   Copyright (C) 2014 - 2016 Jan Fostier (jan.fostier@intec.ugent.be)    *
  *   This file is part of Brownie                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -20,7 +19,6 @@
  ***************************************************************************/
 
 #include "library.h"
-
 #include "tkmer.h"
 
 #include "readfile/fastafile.h"
@@ -173,13 +171,76 @@ ReadFile* ReadLibrary::allocateReadFile() const
                         return NULL;
         }
 
-        assert ( false );
+        assert(false);
         return NULL;
+}
+
+// ============================================================================
+// RECORDBLOCK CLASS
+// ============================================================================
+
+void RecordBlock::getRecordChunk(vector< ReadRecord >& buffer,
+                                 size_t& chunkOffset, size_t targetChunkSize)
+{
+        assert(numChunksRead < numChunks);
+
+        chunkOffset = nextChunkOffset;
+
+        // find out how many records to copy
+        size_t thisChunkSize = 0;
+        for (size_t i = nextChunkOffset; i < recordBuffer.size(); i++) {
+                nextChunkOffset++;
+                thisChunkSize += recordBuffer[i].getReadLength() + 1 - Kmer::getK();
+                buffer.push_back(recordBuffer[i]);
+                if (thisChunkSize >= targetChunkSize)
+                        break;
+        }
+
+        numChunksRead++;
+}
+
+void RecordBlock::getReadChunk(vector< string >& buffer,
+                               size_t& chunkOffset, size_t targetChunkSize)
+{
+        assert(numChunksRead < numChunks);
+
+        chunkOffset = nextChunkOffset;
+
+        // find out how many records to copy
+        size_t thisChunkSize = 0;
+        for (size_t i = nextChunkOffset; i < recordBuffer.size(); i++) {
+                nextChunkOffset++;
+                thisChunkSize += recordBuffer[i].getReadLength() + 1 - Kmer::getK();
+                buffer.push_back(recordBuffer[i].getRead());
+                if (thisChunkSize >= targetChunkSize)
+                        break;
+        }
+
+        numChunksRead++;
+}
+
+void RecordBlock::writeRecordChunk(const vector< ReadRecord >& buffer,
+                                   size_t chunkOffset)
+{
+        copy(buffer.begin(), buffer.end(), recordBuffer.begin() + chunkOffset);
+        numChunksWritten++;
 }
 
 // ============================================================================
 // LIBRARY CONTAINER CLASS
 // ============================================================================
+
+double LibraryContainer::getAvgReadLength() const
+{
+        size_t sumReadLength = 0;
+        size_t sumReads = 0;
+        for (const ReadLibrary& lib : container) {
+                sumReadLength += lib.getAvgReadLength() * lib.getNumReads();
+                sumReads += lib.getNumReads();
+        }
+
+        return (double)sumReadLength/(double)sumReads;
+}
 
 bool LibraryContainer::getRecordChunk(vector<ReadRecord>& buffer,
                                       size_t& blockID, size_t& recordOffset)
@@ -187,34 +248,53 @@ bool LibraryContainer::getRecordChunk(vector<ReadRecord>& buffer,
         // clear the buffer
         buffer.clear();
 
-        // wait until reads become available
-        std::unique_lock<std::mutex> lock(inputMutex);
-        readBufReady.wait(lock, [this]{return ((actReadBlockOffset < actReadBuffer->size()) ||
-                                               (!inputThreadWorking)); });
+        // A) wait until work becomes available or the input thread stopped working
+        std::unique_lock<std::mutex> workLock(workMutex);
+        workReady.wait(workLock, [this]{return workBlocks.find(currWorkBlockID) !=
+                                               workBlocks.end(); });
 
-        blockID = actReadBlockID;
-        recordOffset = actReadBlockOffset;
+        // B) get the current working block
+        RecordBlock *block = workBlocks[currWorkBlockID];
 
-        // find out how many records to copy
-        size_t thisChunkSize = 0;
-        for (size_t i = recordOffset; i < actReadBuffer->size(); i++) {
-                actReadBlockOffset++;
-                thisChunkSize += (*actReadBuffer)[i].getReadLength() + 1 - Kmer::getK();
-                if (thisChunkSize >= targetChunkSize)
-                        break;
+        // check if it is a termination message (NULL)
+        if (block == NULL) {
+                workLock.unlock();
+
+                // send a termination message to the output thread
+                std::unique_lock<std::mutex> outputLock(inputMutex);
+                outputBlocks[currWorkBlockID] = NULL;
+                outputLock.unlock();
+
+                // and get out
+                return false;
         }
 
-        // actually copy records
-        buffer = vector<ReadRecord>(actReadBuffer->begin() + recordOffset,
-                                    actReadBuffer->begin() + actReadBlockOffset);
+        // if not, get a chunk of work
+        blockID = block->getBlockID();
+        block->getRecordChunk(buffer, recordOffset, targetChunkSize);
 
-        // if you took the final block of reads, notify the input thread
-        if (actReadBlockOffset >= actReadBuffer->size())
-                readBufEmpty.notify_one();
+        // C) if you took the last chunk, increase currWorkBlockID
+        bool moveToNextBlock = !block->chunkAvailable();
+        if (moveToNextBlock)
+                currWorkBlockID++;
 
-        lock.unlock();
+        // D.a) if no output thread is active, remove block from work queue
+        if (moveToNextBlock && !outputThreadActive)
+                workBlocks.erase(block->getBlockID());
 
-        return !buffer.empty();
+        workLock.unlock();
+
+        // D.b) if no output thread is active, return block to input queue
+        if (moveToNextBlock && !outputThreadActive) {
+                std::unique_lock<std::mutex> inputLock(inputMutex);
+                block->reset();
+                inputBlocks.push_back(block);
+                inputReady.notify_one();
+                inputLock.unlock();
+        }
+
+        assert(!buffer.empty());
+        return true;
 }
 
 bool LibraryContainer::getReadChunk(vector<string>& buffer,
@@ -223,38 +303,60 @@ bool LibraryContainer::getReadChunk(vector<string>& buffer,
         // clear the buffer
         buffer.clear();
 
-        // wait until reads become available
-        std::unique_lock<std::mutex> lock(inputMutex);
-        readBufReady.wait(lock, [this]{return ((actReadBlockOffset < actReadBuffer->size()) ||
-                                               (!inputThreadWorking)); });
+        // A) wait until work becomes available or the input thread stopped working
+        std::unique_lock<std::mutex> workLock(workMutex);
+        workReady.wait(workLock, [this]{return workBlocks.find(currWorkBlockID) !=
+                                               workBlocks.end(); });
 
-        blockID = actReadBlockID;
-        recordOffset = actReadBlockOffset;
+        // B) get the current working block
+        RecordBlock *block = workBlocks[currWorkBlockID];
 
-        // find out how many records to copy
-        size_t thisChunkSize = 0;
-        for (size_t i = recordOffset; i < actReadBuffer->size(); i++) {
-                actReadBlockOffset++;
-                thisChunkSize += (*actReadBuffer)[i].getReadLength() + 1 - Kmer::getK();
-                buffer.push_back((*actReadBuffer)[i].getRead());
-                if (thisChunkSize >= targetChunkSize)
-                        break;
+        // check if it is a termination message (NULL)
+        if (block == NULL) {
+                workLock.unlock();
+
+                // send a termination message to the output thread
+                std::unique_lock<std::mutex> outputLock(inputMutex);
+                outputBlocks[currWorkBlockID] = NULL;
+                outputLock.unlock();
+
+                // and get out
+                return false;
         }
 
-        // if you took the final block of reads, notify the input thread
-        if (actReadBlockOffset >= actReadBuffer->size())
-                readBufEmpty.notify_one();
+        // if not, get a chunk of work
+        blockID = block->getBlockID();
+        block->getReadChunk(buffer, recordOffset, targetChunkSize);
 
-        lock.unlock();
+        // C) if you took the last chunk, increase currWorkBlockID
+        bool moveToNextBlock = !block->chunkAvailable();
+        if (moveToNextBlock)
+                currWorkBlockID++;
 
-        return !buffer.empty();
+        // D.a) if no output thread is active, remove block from work queue
+        if (moveToNextBlock && !outputThreadActive)
+                workBlocks.erase(block->getBlockID());
+
+        workLock.unlock();
+
+        // D.b) if no output thread is active, return block to input queue
+        if (moveToNextBlock && !outputThreadActive) {
+                std::unique_lock<std::mutex> inputLock(inputMutex);
+                block->reset();
+                inputBlocks.push_back(block);
+                inputReady.notify_one();
+                inputLock.unlock();
+        }
+
+        assert(!buffer.empty());
+        return true;
 }
 
 
 void LibraryContainer::inputThreadLibrary(ReadLibrary& input)
 {
         // read counters
-        size_t totNumReads = 0, numTooShort = 0, totReadLength = 0;
+        size_t totNumReads = 0, totReadLength = 0;
 
         // open the read file
         ReadFile *readFile = input.allocateReadFile();
@@ -263,24 +365,29 @@ void LibraryContainer::inputThreadLibrary(ReadLibrary& input)
         // aux variables
         ReadRecord record;
 
-        while (true) {
-                // fill up the idle read buffer (only this thread has access)
-                idlReadBuffer->clear();
+        while (readFile->good()) {
+                // A) wait until a record block is available
+                std::unique_lock<std::mutex> inputLock(inputMutex);
+                inputReady.wait(inputLock, [this]{return !inputBlocks.empty();});
+
+                // get a record block
+                RecordBlock *block = inputBlocks.back();
+                inputBlocks.pop_back();
+
+                inputLock.unlock();
+
+                // B) fill up the block (only this thread has access)
+                block->reset();
+
+                vector<ReadRecord> &recordBuffer = block->getRecordBuffer();
                 size_t thisBlockSize = 0, thisBlockNumRecords = 0;
                 size_t thisBlockNumChunks = 0, thisChunkSize = 0;
-                while ((thisBlockSize < targetBlockSize) &&
-                        readFile->getNextRecord(record)) {
+                while ((thisBlockSize < targetBlockSize) && (readFile->getNextRecord(record))) {
                         thisBlockNumRecords++;
                         totNumReads++;
                         totReadLength += record.getReadLength();
 
-                        // if the read is short than k, no need to process it
-                        /*if (record.getReadLength() < Kmer::getK()) {
-                                numTooShort++;
-                                continue;
-                        }*/
-
-                        idlReadBuffer->push_back(record);
+                        recordBuffer.push_back(record);
                         thisBlockSize += record.getReadLength() + 1 - Kmer::getK();
 
                         // count the number of chunks in this block
@@ -295,67 +402,64 @@ void LibraryContainer::inputThreadLibrary(ReadLibrary& input)
                 if (thisChunkSize > 0)
                         thisBlockNumChunks++;
 
-                cout << "Number of reads processed: " << totNumReads << "\r"; cout.flush();
+                block->setBlockInfo(currInputFileID, currInputBlockID++, thisBlockNumChunks);
 
-                // wait until active buffer is empty
-                std::unique_lock<std::mutex> lock(inputMutex);
-                readBufEmpty.wait(lock, [this]{return actReadBlockOffset >= actReadBuffer->size();});
-
-                actReadBuffer->clear();
-                actReadBlockOffset = 0;
-                actReadBlockID++;
-
-                // swap active buffer and idle buffer
-                std::swap(actReadBuffer, idlReadBuffer);
-
-                BlockID blockID(actReadFileID, actReadBlockID, thisBlockNumChunks, thisBlockNumRecords);
-                blockQueue.push(blockID);
+                // C) push the record block onto the worker stack
+                std::unique_lock<std::mutex> workLock(workMutex);
+                workBlocks[block->getBlockID()] = block;
 
                 // notify workers that more work is available
-                readBufReady.notify_all();
-                lock.unlock();
+                workReady.notify_all();
+                workLock.unlock();
 
-                // file has completely been read
-                if (!readFile->good())
-                        break;
+                // D) update stdout information
+
+                // FIXME: comment
+                cout << "INPUT THREAD READ BLOCK (FILE: " << currInputFileID
+                     << ", BLOCK: " << block->getBlockID() << ", NUMCHUNKS: "
+                     << thisBlockNumChunks << ", RECORDS: " << recordBuffer.size() << ")" << endl;
+
+                // FIXME: uncomment
+                //cout << "Number of reads processed: " << totNumReads << "\r"; cout.flush();
         }
 
         cout << "Number of reads processed: " << totNumReads << endl;
-        cout << "Average read length: " << totReadLength/totNumReads << endl;
-        input.setReadLength(totReadLength/totNumReads);
+
+        input.setAvgReadLength(totReadLength/totNumReads);
         input.setNumReads(totNumReads);
 
         readFile->close();
+
         // free temporary memory
         delete readFile;
-
-        // issue a warning about skipped reads
-        if (numTooShort > 0) {
-                double perc = 100.0 * (double)numTooShort/(double)totNumReads;
-                streamsize prev = cout.precision (2);
-
-                cout << "\n\tWARNING: Skipped " << numTooShort << " reads ("
-                     << perc << "% of total) because they were shorter than "
-                     << "the kmer size" << endl;
-
-                cout.precision(prev);
-        }
 }
 
 void LibraryContainer::commitRecordChunk(const vector<ReadRecord>& buffer,
                                          size_t blockID, size_t recordOffset)
 {
-        // wait until write becomes available
-        std::unique_lock<std::mutex> lock(outputMutex);
-        writeBufReady.wait(lock, [this, blockID]{return blockID == actWriteBlockID;});
+        // A) obtain the work mutex
+        std::unique_lock<std::mutex> workLock(workMutex);
 
-        copy(buffer.begin(), buffer.end(), actOutputBuffer->begin() + recordOffset);
+        // B) get the corresponding block and write the contents
+        RecordBlock *block = workBlocks[blockID];
+        block->writeRecordChunk(buffer, recordOffset);
 
-        actWriteChunksLeft--;
-        if (actWriteChunksLeft == 0)
-                writeBufFull.notify_one();
+        // C.a) if the block is ready, pass it to the output thread
+        bool blockReady = block->isProcessed();
+        if (blockReady)
+                workBlocks.erase(block->getBlockID());
 
-        lock.unlock();
+        workLock.unlock();
+
+        // C.b) if the block is ready, pass it to the output thread
+        if (blockReady) {
+                cout << "BLOCK " << block->getBlockID() << " IS READY" << endl;     // FIXME: delete
+                std::unique_lock<std::mutex> outputLock(outputMutex);
+                outputBlocks[block->getBlockID()] = block;
+
+                outputReady.notify_one();
+                outputLock.unlock();
+        }
 }
 
 void LibraryContainer::outputThreadLibrary(ReadLibrary& input)
@@ -365,50 +469,50 @@ void LibraryContainer::outputThreadLibrary(ReadLibrary& input)
         readFile->open(input.getOutputFileName(), WRITE);
 
         while (true) {
-                // wait until the input thread has read a new block
-                std::unique_lock<std::mutex> ilock(inputMutex);
-                readBufReady.wait(ilock, [this]{return ((!blockQueue.empty()) ||
-                                                        (!inputThreadWorking)); });
+                // A) wait until an output block is ready
+                std::unique_lock<std::mutex> outputLock(outputMutex);
+                cout << "OUTPUT: " << currOutputBlockID << endl;
+                outputReady.wait(outputLock, [this]{return (outputBlocks.find(currOutputBlockID) !=
+                                                            outputBlocks.end()); });
 
-                // if more work is available, get it from the queue
-                bool moveToNextFile = true;
-                BlockID blockID;
-                if (!blockQueue.empty()) {
-                        blockID = blockQueue.front();
-                        blockQueue.pop();
-                        if (blockID.fileID == actWriteFileID)
-                                moveToNextFile = false;
+                // B) get the next output block
+                RecordBlock* block = outputBlocks[currOutputBlockID];
+                assert(block == outputBlocks.begin()->second);
+
+                // check if it is a termination message (NULL)
+                if (block == NULL) {
+                        outputLock.unlock();
+                        break;
                 }
 
-                ilock.unlock();
+                // C) if we need to start a new file: get out
+                if (block->getFileID() != currOutputFileID) {
+                        outputLock.unlock();
+                        break;
+                }
 
-                // wait until active buffer is full
-                std::unique_lock<std::mutex> lock(outputMutex);
-                writeBufFull.wait(lock, [this]{return actWriteChunksLeft == 0;});
+                // D) remove the block from the output queue
+                outputBlocks.erase(currOutputBlockID);
+                currOutputBlockID++;
 
-                // swap active buffer and idle buffer
-                std::swap(actOutputBuffer, idlOutputBuffer);
+                outputLock.unlock();
 
-                actWriteBlockID = blockID.blockID;
-                actWriteChunksLeft = blockID.numChunks;
-                actOutputBuffer->resize(blockID.numRecords);
-
-                // notify workers that work can again be written
-                writeBufReady.notify_all();
-                lock.unlock();
-
-                // write the idle read buffer (only this thread has access)
-                for (size_t i = 0; i < idlOutputBuffer->size(); i++)
-                        readFile->writeRecord((*idlOutputBuffer)[i]);
+                // E) write the actual data (only this thread has access)
+                const vector<ReadRecord>& recordBuffer = block->getRecordBuffer();
+                for (size_t i = 0; i < recordBuffer.size(); i++)
+                        readFile->writeRecord(recordBuffer[i]);
 
                 if (!readFile->good())
                         throw ios_base::failure("Cannot write to " + input.getOutputFileName());
 
-                idlOutputBuffer->clear();
+                cout << "OUTPUT THREAD WROTE DATA (FILE: " << block->getFileID() << ", BLOCK: " << block->getBlockID() << ", RECORDS: " << block->getRecordBuffer().size() << ")" << endl;
 
-                // if we need to start a new file: get out
-                if (moveToNextFile)
-                        break;
+                // F) return the block to the input queue
+                block->reset();
+                std::unique_lock<std::mutex> inputLock(inputMutex);
+                inputBlocks.push_back(block);
+                inputReady.notify_one();
+                inputLock.unlock();
         }
 
         readFile->close();
@@ -422,67 +526,70 @@ void LibraryContainer::inputThreadEntry()
                 ReadLibrary &input = getInput(i);
 
                 cout << "Processing file " << i+1 << "/" << getSize() << ": "
-                     << input.getInputFilename() << ", type: " << input.getFileType()
-                     << endl;
+                     << input.getInputFilename() << ", type: "
+                     << input.getFileType() << endl;
 
                 inputThreadLibrary(input);
-                actReadFileID++;
+                currInputFileID++;
         }
 
         // wait until active buffer is empty
-        unique_lock<std::mutex> lock(inputMutex);
-        inputThreadWorking = false;
-        readBufReady.notify_all();
-        lock.unlock();
+        unique_lock<std::mutex> workLock(workMutex);
+        workBlocks[currInputBlockID] = NULL;
+        workReady.notify_all();
+        workLock.unlock();
 }
 
 void LibraryContainer::outputThreadEntry()
 {
-        // write all data
+        // write all output data
         for (size_t i = 0; i < getSize(); i++) {
                 ReadLibrary &input = getInput(i);
+
                 outputThreadLibrary(input);
-                actWriteFileID++;
+                currOutputFileID++;
         }
 }
 
 void LibraryContainer::startIOThreads(size_t targetChunkSize_,
                                       size_t targetBlockSize_,
-                                      bool writeReads)
+                                      bool outputThreadActive_)
 {
         targetChunkSize = targetChunkSize_;
         targetBlockSize = targetBlockSize_;
+        outputThreadActive = outputThreadActive_;
 
-        // input threads
-        inputThreadWorking = true;
-        actReadBuffer = new vector<ReadRecord>;
-        idlReadBuffer = new vector<ReadRecord>;
-        actReadFileID = actReadBlockID = actReadBlockOffset = 0;
+        // initialize input variables
+        currInputFileID = currInputBlockID = 0;
 
+        // initialize work thread variables
+        currWorkBlockID = 0;
+
+        // initialize output variables
+        currOutputFileID = currOutputBlockID = 0;
+
+        // initialize blocks and push them on the input stack
+        for (int i = 0; i < NUM_RECORD_BLOCKS; i++)
+                inputBlocks.push_back(new RecordBlock());
+
+        // start IO threads
         iThread = thread(&LibraryContainer::inputThreadEntry, this);
-
-        if (!writeReads)
-                return;
-
-        actOutputBuffer = new vector<ReadRecord>;
-        idlOutputBuffer = new vector<ReadRecord>;
-        actWriteFileID = actWriteBlockID = actWriteChunksLeft = 0;
-        oThread = thread(&LibraryContainer::outputThreadEntry, this);
+        if (outputThreadActive)
+                oThread = thread(&LibraryContainer::outputThreadEntry, this);
 }
 
 void LibraryContainer::joinIOThreads()
 {
         iThread.join();
 
-        delete idlReadBuffer; idlReadBuffer = NULL;
-        delete actReadBuffer; actReadBuffer = NULL;
-
-        if (oThread.joinable()) {
+        if (oThread.joinable())         // output thread might not be active
                 oThread.join();
-                delete idlOutputBuffer; idlOutputBuffer = NULL;
-                delete actOutputBuffer; actOutputBuffer = NULL;
-        }
 
-        // make sure the queue is empty
-        std::queue<BlockID>().swap(blockQueue);
+        assert(inputBlocks.size() == NUM_RECORD_BLOCKS);
+        // delete blocks and clear the input stack
+        for (size_t i = 0; i < inputBlocks.size(); i++)
+                delete inputBlocks[i];
+        inputBlocks.clear();            // contains all blocks
+        workBlocks.clear();             // contains only a termination msg
+        outputBlocks.clear();           // contains only a termination msg
 }

--- a/src/library.cpp
+++ b/src/library.cpp
@@ -413,14 +413,7 @@ void LibraryContainer::inputThreadLibrary(ReadLibrary& input)
                 workLock.unlock();
 
                 // D) update stdout information
-
-                // FIXME: comment
-                cout << "INPUT THREAD READ BLOCK (FILE: " << currInputFileID
-                     << ", BLOCK: " << block->getBlockID() << ", NUMCHUNKS: "
-                     << thisBlockNumChunks << ", RECORDS: " << recordBuffer.size() << ")" << endl;
-
-                // FIXME: uncomment
-                //cout << "Number of reads processed: " << totNumReads << "\r"; cout.flush();
+                cout << "Number of reads processed: " << totNumReads << "\r"; cout.flush();
         }
 
         cout << "Number of reads processed: " << totNumReads << endl;
@@ -453,7 +446,6 @@ void LibraryContainer::commitRecordChunk(const vector<ReadRecord>& buffer,
 
         // C.b) if the block is ready, pass it to the output thread
         if (blockReady) {
-                cout << "BLOCK " << block->getBlockID() << " IS READY" << endl;     // FIXME: delete
                 std::unique_lock<std::mutex> outputLock(outputMutex);
                 outputBlocks[block->getBlockID()] = block;
 
@@ -471,7 +463,6 @@ void LibraryContainer::outputThreadLibrary(ReadLibrary& input)
         while (true) {
                 // A) wait until an output block is ready
                 std::unique_lock<std::mutex> outputLock(outputMutex);
-                cout << "OUTPUT: " << currOutputBlockID << endl;
                 outputReady.wait(outputLock, [this]{return (outputBlocks.find(currOutputBlockID) !=
                                                             outputBlocks.end()); });
 
@@ -504,8 +495,6 @@ void LibraryContainer::outputThreadLibrary(ReadLibrary& input)
 
                 if (!readFile->good())
                         throw ios_base::failure("Cannot write to " + input.getOutputFileName());
-
-                cout << "OUTPUT THREAD WROTE DATA (FILE: " << block->getFileID() << ", BLOCK: " << block->getBlockID() << ", RECORDS: " << block->getRecordBuffer().size() << ")" << endl;
 
                 // F) return the block to the input queue
                 block->reset();

--- a/src/library.h
+++ b/src/library.h
@@ -239,7 +239,6 @@ public:
          */
         void writeRecordChunk(const std::vector<ReadRecord>& buffer,
                               size_t chunkOffset);
-
 };
 
 // ============================================================================

--- a/src/library.h
+++ b/src/library.h
@@ -1,6 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2014, 2015 Jan Fostier (jan.fostier@intec.ugent.be)     *
- *   Copyright (C) 2014, 2015 Mahdi Heydari (mahdi.heydari@intec.ugent.be) *
+ *   Copyright (C) 2014 - 2016 Jan Fostier (jan.fostier@intec.ugent.be)    *
  *   This file is part of Brownie                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -23,13 +22,14 @@
 #define READLIBRARY_H
 
 #include "global.h"
+#include "tkmer.h"
 #include "readfile/readfile.h"
 
 #include <string>
 #include <sstream>
 #include <fstream>
 #include <vector>
-#include <queue>
+#include <map>
 
 #include <mutex>
 #include <condition_variable>
@@ -85,7 +85,7 @@ public:
          * Get the output filename
          * @return The output filename
          */
-        std::string getOutputFileName(){
+        std::string getOutputFileName() const {
                 return outputFilename;
         }
 
@@ -117,7 +117,7 @@ public:
          * Set the read length
          * @param target The read length
          */
-        void setReadLength(double target) {
+        void setAvgReadLength(double target) {
                 avgReadLength = target;
         }
 
@@ -125,35 +125,126 @@ public:
          * Get the read length
          * @return The read length
          */
-        double getReadLength() const {
+        double getAvgReadLength() const {
                 return avgReadLength;
         }
 };
 
 // ============================================================================
-// LIBRARYCONTAINER CLASS
+// RECORDBLOCK CLASS
 // ============================================================================
 
-class BlockID
+class RecordBlock
 {
+private:
+        size_t fileID;                  // file identifier
+        size_t blockID;                 // block identifier
+        size_t numChunks;               // number of chunks within this block
+        size_t numChunksRead;           // number of chunks read
+        size_t numChunksWritten;        // number of chunks written
+        size_t nextChunkOffset;         // offset of the next chunk to be read
+
+        std::vector<ReadRecord> recordBuffer;   // actual records
+
 public:
         /**
          * Default constructor
          */
-        BlockID() : fileID(0), blockID(0), numChunks(0), numRecords(0) {}
+        RecordBlock() : fileID(0), blockID(0), numChunks(0),
+                numChunksRead(0), numChunksWritten(0), nextChunkOffset(0) {}
 
         /**
-         * Default constructor
+         * Clear the contents of this block
          */
-        BlockID(size_t fileID_, size_t blockID_, size_t numChunks_,
-                size_t numRecords_) : fileID(fileID_), blockID(blockID_),
-                numChunks(numChunks_), numRecords(numRecords_) {}
+        void reset() {
+                fileID = blockID = numChunks = numChunksRead = 0;
+                numChunksWritten = nextChunkOffset = 0;
+                recordBuffer.clear();
+        }
 
-        size_t fileID;          // file identifier to which this block belongs
-        size_t blockID;         // unique block identifier within this file
-        size_t numChunks;       // number of chunks within this block
-        size_t numRecords;      // number of records within this block
+        /**
+         * Return the blockID
+         * @return The blockID
+         */
+        size_t getBlockID() const {
+                return blockID;
+        }
+
+        /**
+         * Return the fileID
+         * @return The fileID
+         */
+        size_t getFileID() const {
+                return fileID;
+        }
+
+        /**
+         * Return true of at least one chunk if available for reading
+         * @param true or false
+         */
+        bool chunkAvailable() const {
+                return numChunksRead < numChunks;
+        }
+
+        /**
+         * Returns true if the block is fully processed
+         * @return true of false
+         */
+        bool isProcessed() const {
+                return numChunksWritten == numChunks;
+        }
+
+        /**
+         * Accessor to the record buffer
+         * @return A reference to the record buffer
+         */
+        std::vector<ReadRecord>& getRecordBuffer() {
+                return recordBuffer;
+        }
+
+        /**
+         * Set the block meta information
+         * @param fileID_ File identifier
+         * @param blockID_ Block identifier
+         * @param numChunks_ Number of chunks in this block
+         */
+        void setBlockInfo(size_t fileID_, size_t blockID_, size_t numChunks_) {
+                fileID = fileID_;
+                blockID = blockID_;
+                numChunks = numChunks_;
+        }
+
+        /**
+         * Get next available input record chunk
+         * @param buffer Record buffer to write to (contents will be appended)
+         * @param chunkOffset Chunk offset (output)
+         * @param targetChunkSize Target chunk size (input)
+         */
+        void getRecordChunk(std::vector<ReadRecord>& buffer,
+                            size_t& chunkOffset, size_t targetChunkSize);
+
+        /**
+         * Get next available input read chunk
+         * @param buffer Record buffer to write to (contents will be appended)
+         * @param chunkOffset Chunk offset (output)
+         * @param targetChunkSize Target chunk size (input)
+         */
+        void getReadChunk(std::vector<std::string>& buffer,
+                          size_t& chunkOffset, size_t targetChunkSize);
+
+        /**
+         * Replace a chunk with the contents provided by the buffer
+         * @param buffer Record buffer with new contents
+         * @param chunkOffset Record offset of the chunk
+         */
+        void writeRecordChunk(const std::vector<ReadRecord>& buffer,
+                              size_t chunkOffset);
+
 };
+
+// ============================================================================
+// LIBRARYCONTAINER CLASS
+// ============================================================================
 
 class LibraryContainer
 {
@@ -163,30 +254,29 @@ private:
         size_t targetBlockSize;                         // a block is a number of (overlapping) k-mers read in a single run
         size_t targetChunkSize;                         // a chunk is a piece of work attributed to one thread
 
-        std::queue<BlockID> blockQueue;                 // queue holding all blocks to be processed
-
-        // variables for thread-safe reading
         std::thread iThread;                            // input thread
-        bool inputThreadWorking;                        // input thread still working
-        std::mutex inputMutex;                          // input thread mutex
-        std::condition_variable readBufReady;           // read buffer full condition
-        std::condition_variable readBufEmpty;           // read buffer empty condition
-        std::vector<ReadRecord> *actReadBuffer;         // active read buffer
-        std::vector<ReadRecord> *idlReadBuffer;         // idle read buffer
-        size_t actReadFileID;                           // identifier of the active read file
-        size_t actReadBlockID;                          // identifier of the active read block ID
-        size_t actReadBlockOffset;                      // offset within the active read block
-
-        // variables for thread-safe writing
         std::thread oThread;                            // output thread
+        bool outputThreadActive;                        // is the output thread active?
+
+        // input thread variables (protect by inputMutex)
+        std::mutex inputMutex;                          // input thread mutex
+        std::condition_variable inputReady;             // input blocks ready condition
+        std::vector<RecordBlock*> inputBlocks;          // input blocks that are empty
+        size_t currInputFileID;                         // identifier of the current input file
+        size_t currInputBlockID;                        // identifier of the current input block
+
+        // worker thread variables (protect by workMutex)
+        std::mutex workMutex;                           // worker thread mutex
+        std::condition_variable workReady;              // work ready condition
+        std::map<size_t, RecordBlock*> workBlocks;      // blocks being processed
+        size_t currWorkBlockID;                         // identifier of the block currently being processed
+
+        // output thread variables (protect by outputMutex)
         std::mutex outputMutex;                         // output thread mutex
-        std::condition_variable writeBufReady;          // write buffer ready condition
-        std::condition_variable writeBufFull;           // write buffer full condition
-        std::vector<ReadRecord> *actOutputBuffer;       // active write buffer
-        std::vector<ReadRecord> *idlOutputBuffer;       // idle write buffer
-        size_t actWriteFileID;                          // identifier of the output file
-        size_t actWriteBlockID;                         // identifier of the output block
-        size_t actWriteChunksLeft;                      // number of chunks left in active write block
+        std::condition_variable outputReady;            // write buffer full condition
+        std::map<size_t, RecordBlock*> outputBlocks;    // processed blocks
+        size_t currOutputFileID;                        // identifier of the current output file
+        size_t currOutputBlockID;                       // identifier of the current output block
 
         /**
          * Write the inputs for a specific library
@@ -248,6 +338,12 @@ public:
         }
 
         /**
+         * The (weighted) average read length over all libraries
+         * @return The (weighted) average read length over all libraries
+         */
+        double getAvgReadLength() const;
+
+        /**
          * Get next record chunk from the input
          * @param buffer Buffer in which to store the records (output)
          * @param blockID Block identifier (output)
@@ -287,20 +383,12 @@ public:
                             bool writeReads = false);
 
         /**
-         * Finalize read threading
+         * Join input (and optionally) also the output thread
+         * Make sure that all worker threads are joined before calling this
+         * routine.  Calling getReadChunk() or commitRecordChunk() after this
+         * routine is called will result in undefined behavior
          */
         void joinIOThreads();
-
-        double getReadLength() const {
-                size_t readLengthAvg = 0;
-                size_t totalNumOfReads = 0;
-                for (auto it : container){
-                        readLengthAvg=((readLengthAvg *totalNumOfReads)+it.getReadLength()*it.getNumReads())/(totalNumOfReads+it.getNumReads());
-                        totalNumOfReads=totalNumOfReads+it.getNumReads();
-                }
-                return readLengthAvg;
-
-        }
 };
 
 #endif

--- a/src/library.h
+++ b/src/library.h
@@ -22,7 +22,6 @@
 #define READLIBRARY_H
 
 #include "global.h"
-#include "tkmer.h"
 #include "readfile/readfile.h"
 
 #include <string>
@@ -56,7 +55,7 @@ private:
         FileType fileType;              // file type (FASTQ, FASTA, etc.)
 
         size_t numReads;                // number of reads in library
-        double avgReadLength;           // average size of the reads
+        double avgReadLength;           // average length of the reads
 
 public:
         /**
@@ -139,7 +138,7 @@ class RecordBlock
 private:
         size_t fileID;                  // file identifier
         size_t blockID;                 // block identifier
-        size_t numChunks;               // number of chunks within this block
+        size_t numChunks;               // number of chunks in this block
         size_t numChunksRead;           // number of chunks read
         size_t numChunksWritten;        // number of chunks written
         size_t nextChunkOffset;         // offset of the next chunk to be read
@@ -180,7 +179,7 @@ public:
 
         /**
          * Return true of at least one chunk if available for reading
-         * @param true or false
+         * @return true or false
          */
         bool chunkAvailable() const {
                 return numChunksRead < numChunks;

--- a/src/readcorrection.cpp
+++ b/src/readcorrection.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2015, 2016 Jan Fostier (jan.fostier@intec.ugent.be)     *
+ *   Copyright (C) 2014, 2015 Jan Fostier (jan.fostier@intec.ugent.be)     *
  *   This file is part of Brownie                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -20,7 +20,6 @@
 
 #include <thread>
 #include <string>
-#include <chrono>
 #include "library.h"
 #include "readcorrection.h"
 #include "kmernode.h"
@@ -544,9 +543,6 @@ void ReadCorrectionHandler::workerThread(size_t myID, LibraryContainer& librarie
                 size_t blockID, recordID;
                 bool result = libraries.getRecordChunk(myReadBuf, blockID, recordID);
 
-                cout << "Thread " << myID << " starting new chunk block ID " << blockID << ", recordID " << recordID << endl;
-             //   if (myID == 0)
-              //          std::this_thread::sleep_for(chrono::seconds(60));
                 readCorrection.correctChunk(myReadBuf);
 
                 if (result)

--- a/src/readcorrection.cpp
+++ b/src/readcorrection.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2014, 2015 Jan Fostier (jan.fostier@intec.ugent.be)     *
+ *   Copyright (C) 2015, 2016 Jan Fostier (jan.fostier@intec.ugent.be)     *
  *   This file is part of Brownie                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -20,6 +20,7 @@
 
 #include <thread>
 #include <string>
+#include <chrono>
 #include "library.h"
 #include "readcorrection.h"
 #include "kmernode.h"
@@ -543,6 +544,9 @@ void ReadCorrectionHandler::workerThread(size_t myID, LibraryContainer& librarie
                 size_t blockID, recordID;
                 bool result = libraries.getRecordChunk(myReadBuf, blockID, recordID);
 
+                cout << "Thread " << myID << " starting new chunk block ID " << blockID << ", recordID " << recordID << endl;
+             //   if (myID == 0)
+              //          std::this_thread::sleep_for(chrono::seconds(60));
                 readCorrection.correctChunk(myReadBuf);
 
                 if (result)


### PR DESCRIPTION
This is a major rewrite of the LibraryContainer class, more specifically the functionality for parallel I/O. Additionally, I've taken the opportunity to clean up the entire library.cpp and library.h file.  This includes the refactoring of the other classes in those files (RecordBlock and ReadLibrary).

The rewrite of the LibraryContainer was necessary because only limited parallelism across RecordBlocks was allowed in the previous version.  More specifically, a worker thread could not commit a chunk to a RecordBlock if the previous RecordBlock was not yet completed. In practice, handling a new RecordBlock caused thread synchronization until the last chunks from the old block were completed.

In the current version, parallelism across RecordBlocks is unlimited. The only restriction is the number of RecordBlocks simulateneously held in memory. This is controlled by a #define in global.h.  It is currently set to two, which should be fine unless some chunks take excessively long.

Please revise and test thoroughly. I've tested the code with valgrind (no leaks, no helgrind issues) and for functionality (output is identical to master for S. Aureus).
