### PR TITLE
Additional options

### DIFF
--- a/src/bubble.cpp
+++ b/src/bubble.cpp
@@ -1,8 +1,3 @@
-#include "graph.h"
-
-#include "library.h"
-
-
 /***************************************************************************
  *   Copyright (C) 2014, 2015 Jan Fostier (jan.fostier@intec.ugent.be)     *
  *   Copyright (C) 2014, 2015 Mahdi Heydari (mahdi.heydari@intec.ugent.be) *
@@ -26,6 +21,7 @@
 
 #include "graph.h"
 #include "settings.h"
+#include "library.h"
 
 using namespace std;
 class PathInfo {
@@ -296,7 +292,7 @@ vector<pair<vector<NodeID>, vector<NodeID> > >  DBGraph::searchForParallelNodes(
         priority_queue<PathInfo, vector<PathInfo>, comparator> heap;
         heap.push(PathInfo(lID, 0));
         vector<pair<vector<NodeID>, vector<NodeID> > > parallelNodes;
-        size_t visitedNodesLimit = settings.getMaxVisits();
+        size_t visitedNodesLimit = settings.getBubbleDFSNodeLimit();
         while(!heap.empty()) {
                 PathInfo currTop = heap.top();
                 heap.pop();

--- a/src/bubble.cpp
+++ b/src/bubble.cpp
@@ -25,6 +25,7 @@
  ***************************************************************************/
 
 #include "graph.h"
+#include "settings.h"
 
 using namespace std;
 class PathInfo {
@@ -295,7 +296,7 @@ vector<pair<vector<NodeID>, vector<NodeID> > >  DBGraph::searchForParallelNodes(
         priority_queue<PathInfo, vector<PathInfo>, comparator> heap;
         heap.push(PathInfo(lID, 0));
         vector<pair<vector<NodeID>, vector<NodeID> > > parallelNodes;
-        size_t visitedNodesLimit=1000;
+        size_t visitedNodesLimit = settings.getMaxVisits();
         while(!heap.empty()) {
                 PathInfo currTop = heap.top();
                 heap.pop();

--- a/src/essaMEM-master/sparseSA.cpp
+++ b/src/essaMEM-master/sparseSA.cpp
@@ -236,9 +236,7 @@ void sparseSA::construct(){
         delete[] BucketBegin;
 
         // Suffix sort integer text.
-        cerr << "# suffixsort()" << endl;
         suffixsort(t_new, intSA, N/K, bucketNr, 0);
-        cerr << "# DONE suffixsort()" << endl;
 
         delete[] t_new;
 
@@ -918,7 +916,7 @@ void sparseSA::MEM(string &P, vector<match_t> &matches, int min_len, bool print,
 }
 
 void sparseSA::checkMatches(std::string const &P,
-	std::vector<match_t> const &matches, int const min_len) const 
+	std::vector<match_t> const &matches, int const min_len) const
 {
 	for ( int i = 0; i < matches.size(); ++i) {
 		match_t m = matches[i];

--- a/src/global.h
+++ b/src/global.h
@@ -49,8 +49,6 @@ typedef uint32_t KmerLSB;       // set to uint16_t and all hell will break loose
         #define ATTRIBUTE_PACKED
 #endif
 
-#define MAXTOURBUSLENGTH 200
-#define MAXDIVERGENCE 0.2f
 #define MAXGAPS 3
 
 #define MAX_COVERAGE 65535

--- a/src/readcorrection.cpp
+++ b/src/readcorrection.cpp
@@ -590,7 +590,7 @@ void ReadCorrectionHandler::initEssaMEM()
                           refdescr,             //
                           startpos,             //
                           false,                //4 column format or not
-                          1,                    //sparseness
+                          settings.getEssaFactor(),                    //sparseness
                           false,                //suffixlinks
                           true,                 //child arrays
                           1,                    //skip parameter

--- a/src/readcorrection.cpp
+++ b/src/readcorrection.cpp
@@ -175,7 +175,7 @@ void ReadCorrectionJan::recSearch(NodeID curr, string& read, vector<NodePosPair>
         const SSNode node = dbg.getSSNode(curr);
 
         counter++;
-        if (counter > settings.getMaxDepth())
+        if (counter > settings.getReadCorrDFSNodeLimit())
                 return;
 
         vector<DFSNode> dfsNode;
@@ -586,15 +586,15 @@ void ReadCorrectionHandler::initEssaMEM()
         bool printSubstring = false;
         bool printRevCompForw = false;
 
-        sa = new sparseSA(reference,             //reference
-                          refdescr,             //
-                          startpos,             //
-                          false,                //4 column format or not
-                          settings.getEssaFactor(),                    //sparseness
-                          false,                //suffixlinks
-                          true,                 //child arrays
-                          1,                    //skip parameter
-                          printSubstring,       //
+        sa = new sparseSA(reference,                            // reference
+                          refdescr,
+                          startpos,                             // start index for each string
+                          false,                                // 4 column format or not
+                          settings.getESSASparsenessFactor(),   // ESSA sparseness factor
+                          false,                                // suffixlinks
+                          true,                                 // child arrays
+                          1,                                    // skip parameter
+                          printSubstring,
                           printRevCompForw);
         sa->construct();
 }

--- a/src/readcorrection.cpp
+++ b/src/readcorrection.cpp
@@ -175,7 +175,7 @@ void ReadCorrectionJan::recSearch(NodeID curr, string& read, vector<NodePosPair>
         const SSNode node = dbg.getSSNode(curr);
 
         counter++;
-        if (counter > 1000)
+        if (counter > settings.getMaxDepth())
                 return;
 
         vector<DFSNode> dfsNode;

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -84,7 +84,8 @@ void Settings::printUsage() const
 // ============================================================================
 
 Settings::Settings() : kmerSize(31), numThreads(std::thread::hardware_concurrency()),
-        genomeSize(0), doubleStranded(true), essa_factor(1), skip_stage_4(false), skip_stage_5(false) {}
+        genomeSize(0), doubleStranded(true), essa_factor(1), max_visits(1000),
+        max_depth(1000), skip_stage_4(false), skip_stage_5(false) {}
 
 void Settings::parseCommandLineArguments(int argc, char** args,
                                          LibraryContainer& libCont)
@@ -119,6 +120,14 @@ void Settings::parseCommandLineArguments(int argc, char** args,
                         i++;
                         if (i < argc)
                                 essa_factor = atoi(args[i]);
+                } else if ((arg == "-v") || (arg == "--visits")) {
+                        i++;
+                        if (i < argc)
+                                max_visits = atoi(args[i]);
+                } else if ((arg == "-d") || (arg == "--depth")) {
+                        i++;
+                        if (i < argc)
+                                max_depth = atoi(args[i]);
                 } else if ((arg == "-s") || (arg == "--singlestranded")) {
                         doubleStranded = false;
                 } else if ((arg == "-p") || (arg == "--pathtotmp")) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -66,12 +66,15 @@ void Settings::printUsage() const
         cout << "  -k\t--kmersize\t\tkmer size [default = 31]\n";
         cout << "  -t\t--threads\t\tnumber of threads [default = available cores]\n";
         cout << "  -g\t--genomesize\t\tsize of the genome [default = auto]\n";
+        cout << "  -v\t--visits\t\tmaximal number of visited nodes in one bubble detection [default = 1000]\n";
+        cout << "  -d\t--depth\t\t\tmaximal number of visited nodes in one read correction [default = 1000]\n";
+        cout << "  -e\t--essa\t\t\tsparseness factor of the enhanced sparse suffix array [default = 1]\n";
 
         cout << "  -p\t--pathtotmp\t\tpath to directory to store temporary files [default = current directory]\n\n";
 
         cout << " [file_options]\n";
         cout << "  -o\t--output\t\toutput file name [default = inputfile.corr]\n";
-        cout << "  \t--graph\t\tskip read correction\n";
+        cout << "  \t--graph\t\t\tskip read correction\n";
         cout << "  \t--perfectgraph\t\tskip read and graph correction\n\n";
 
         cout << " examples:\n";

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -66,8 +66,8 @@ void Settings::printUsage() const
         cout << "  -k\t--kmersize\t\tkmer size [default = 31]\n";
         cout << "  -t\t--threads\t\tnumber of threads [default = available cores]\n";
         cout << "  -g\t--genomesize\t\tsize of the genome [default = auto]\n";
-        cout << "  -v\t--visits\t\tmaximal number of visited nodes in one bubble detection [default = 1000]\n";
-        cout << "  -d\t--depth\t\t\tmaximal number of visited nodes in one read correction [default = 1000]\n";
+        cout << "  -v\t--visits\t\tmaximum number of visited nodes in one bubble detection [default = 1000]\n";
+        cout << "  -d\t--depth\t\t\tmaximum number of visited nodes in one read correction [default = 1000]\n";
         cout << "  -e\t--essa\t\t\tsparseness factor of the enhanced sparse suffix array [default = 1]\n";
 
         cout << "  -p\t--pathtotmp\t\tpath to directory to store temporary files [default = current directory]\n\n";
@@ -87,8 +87,8 @@ void Settings::printUsage() const
 // ============================================================================
 
 Settings::Settings() : kmerSize(31), numThreads(std::thread::hardware_concurrency()),
-        genomeSize(0), doubleStranded(true), essa_factor(1), max_visits(1000),
-        max_depth(1000), skip_stage_4(false), skip_stage_5(false) {}
+        genomeSize(0), doubleStranded(true), essa_factor(1), bubbleDFSNodeLimit(1000),
+        readCorrDFSNodeLimit(1000), skip_stage_4(false), skip_stage_5(false) {}
 
 void Settings::parseCommandLineArguments(int argc, char** args,
                                          LibraryContainer& libCont)
@@ -126,11 +126,11 @@ void Settings::parseCommandLineArguments(int argc, char** args,
                 } else if ((arg == "-v") || (arg == "--visits")) {
                         i++;
                         if (i < argc)
-                                max_visits = atoi(args[i]);
+                                bubbleDFSNodeLimit = atoi(args[i]);
                 } else if ((arg == "-d") || (arg == "--depth")) {
                         i++;
                         if (i < argc)
-                                max_depth = atoi(args[i]);
+                                readCorrDFSNodeLimit = atoi(args[i]);
                 } else if ((arg == "-s") || (arg == "--singlestranded")) {
                         doubleStranded = false;
                 } else if ((arg == "-p") || (arg == "--pathtotmp")) {

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -84,7 +84,7 @@ void Settings::printUsage() const
 // ============================================================================
 
 Settings::Settings() : kmerSize(31), numThreads(std::thread::hardware_concurrency()),
-        genomeSize(0), doubleStranded(true), skip_stage_4(false), skip_stage_5(false) {}
+        genomeSize(0), doubleStranded(true), essa_factor(1), skip_stage_4(false), skip_stage_5(false) {}
 
 void Settings::parseCommandLineArguments(int argc, char** args,
                                          LibraryContainer& libCont)
@@ -115,6 +115,10 @@ void Settings::parseCommandLineArguments(int argc, char** args,
                         i++;
                         if (i < argc)
                                 genomeSize = atoi(args[i]);
+                } else if ((arg == "-e") || (arg == "--essa")) {
+                        i++;
+                        if (i < argc)
+                                essa_factor = atoi(args[i]);
                 } else if ((arg == "-s") || (arg == "--singlestranded")) {
                         doubleStranded = false;
                 } else if ((arg == "-p") || (arg == "--pathtotmp")) {

--- a/src/settings.h
+++ b/src/settings.h
@@ -53,11 +53,11 @@ private:
         bool doubleStranded;            // double stranded sequences
         std::string pathtotemp;         // directory specified by user
 
-        int essa_factor;		// sparseness factor for essamem
-        int max_visits;			// maximal number of visited nodes for bubble detection
-        int max_depth;			// maximal search depth for stage 5
-        bool skip_stage_4;
-        bool skip_stage_5;
+        int ESSASparsenessFactor;       // sparseness factor for essamem
+        int bubbleDFSNodeLimit;         // maximal number of visited nodes for bubble detection
+        int readCorrDFSNodeLimit;       // maximal search depth for stage 5
+        bool skipStage4;
+        bool skipStage5;
 
 public:
         /**
@@ -130,24 +130,24 @@ public:
                 this->genomeSize=genomeSize;
         }
 
-        int getEssaFactor() const {
-                return essa_factor;
+        int getESSASparsenessFactor() const {
+                return ESSASparsenessFactor;
         }
 
-        int getMaxVisits() const {
-                return max_visits;
+        int getBubbleDFSNodeLimit() const {
+                return bubbleDFSNodeLimit;
         }
 
-        int getMaxDepth() const {
-                return max_depth;
+        int getReadCorrDFSNodeLimit() const {
+                return readCorrDFSNodeLimit;
         }
 
         bool getSkipStage4() const {
-                return skip_stage_4;
+                return skipStage4;
         }
 
         bool getSkipStage5() const {
-                return skip_stage_5;
+                return skipStage5;
         }
 };
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -53,6 +53,7 @@ private:
         bool doubleStranded;            // double stranded sequences
         std::string pathtotemp;         // directory specified by user
 
+        int essa_factor;
         bool skip_stage_4;
         bool skip_stage_5;
 
@@ -125,6 +126,10 @@ public:
 
         void setGenomeSize(){
                 this->genomeSize=genomeSize;
+        }
+
+        int getEssaFactor() const {
+                return essa_factor;
         }
 
         bool getSkipStage4() const {

--- a/src/settings.h
+++ b/src/settings.h
@@ -53,7 +53,9 @@ private:
         bool doubleStranded;            // double stranded sequences
         std::string pathtotemp;         // directory specified by user
 
-        int essa_factor;
+        int essa_factor;		// sparseness factor for essamem
+        int max_visits;			// maximal number of visited nodes for bubble detection
+        int max_depth;			// maximal search depth for stage 5
         bool skip_stage_4;
         bool skip_stage_5;
 
@@ -130,6 +132,14 @@ public:
 
         int getEssaFactor() const {
                 return essa_factor;
+        }
+
+        int getMaxVisits() const {
+                return max_visits;
+        }
+
+        int getMaxDepth() const {
+                return max_depth;
         }
 
         bool getSkipStage4() const {


### PR DESCRIPTION
This adds three additional parameters to brownie:
--visits limits the number of nodes that can be visited in a single bubble detection (stage 4) [default = 1000]
--depth limits the read alignment recursion (stage 5) [default = 1000]
--essa changes the sparseness factor of essaMEM, reducing memory usage [default = 1]
The default values are identical to the values that were hardcoded before these changes were made.

It should be noted that essaMEM does not always find all MEMs when the sparseness factor is larger than 1. This has yet to be fixed. For now, this option allows brownie to run with lower memory usage, but with a possible drop in read correction performance.
