### PR TITLE
To display number of changes in stage 5 in terms of substitutions...

### DIFF
--- a/src/readcorrection.cpp
+++ b/src/readcorrection.cpp
@@ -43,17 +43,26 @@ void AlignmentMetrics::addMetrics(const AlignmentMetrics& rhs)
 
 void AlignmentMetrics::printStatistics() const
 {
+        size_t numCorrByKmer = numCorrReads - numCorrByMEM;
+        size_t numUncorrected = numReads - numCorrReads;
+
         cout << "\nError correction report:\n";
         cout << "\tNumber of reads handled: " << numReads << endl;
         cout << "\tNumber of corrected reads: " << numCorrReads
              << fixed << setprecision(2) << " ("
-             << 100*(double)(numCorrReads)/(double)(numReads) << "%)" << endl;
-        cout << "\tNumber of reads corrected by MEMs: " << numCorrByMEM
+             << Util::toPercentage(numCorrReads, numReads) << "%)" << endl;
+        cout << "\tNumber of reads corrected by kmer seeds: " << numCorrByKmer
              << fixed << setprecision(2) << " ("
-             << 100*(double)(numCorrByMEM)/(double)(numReads) << "%)" << endl;
+             << Util::toPercentage(numCorrByKmer, numReads) << "%)" << endl;
+        cout << "\tNumber of reads corrected by MEM seeds: " << numCorrByMEM
+             << fixed << setprecision(2) << " ("
+             << Util::toPercentage(numCorrByMEM, numReads) << "%)" << endl;
         cout << "\tNumber of subtitutions in reads: " << numSubstitutions
+             << fixed << setprecision(2) << " (avg of "
+             << double(numSubstitutions)/double(numReads) << " per read)" << endl;
+        cout << "\tNumber of uncorrected reads: " << numUncorrected
              << fixed << setprecision(2) << " ("
-             << (double)(numSubstitutions)/(double)(numReads) <<" per read)\n"<< endl;
+             << Util::toPercentage(numUncorrected, numReads) << "%)" << endl;
 }
 
 // ============================================================================

--- a/src/readcorrection.h
+++ b/src/readcorrection.h
@@ -1,5 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2015 Jan Fostier (jan.fostier@intec.ugent.be)           *
+ *   Copyright (C) 2015-2016 Jan Fostier (jan.fostier@intec.ugent.be)      *
  *   This file is part of Brownie                                          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -26,11 +26,93 @@
 #include "alignment.h"
 #include "essaMEM-master/sparseSA.hpp"
 
+#include <mutex>
+
 // ============================================================================
 // CLASS PROTOTYPES
 // ============================================================================
 
 class NodePosPair;
+
+// ============================================================================
+// ALIGNMENT METRICS CLASS
+// ============================================================================
+
+class AlignmentMetrics
+{
+private:
+        size_t numReads;                // number of reads handled
+        size_t numCorrReads;            // number of reads corrected
+        size_t numCorrByMEM;            // number of times MEM procedure was used
+        size_t numSubstitutions;        // number of substitutions made to the reads
+        std::mutex metricMutex;         // mutex for merging metrics
+
+public:
+        /**
+         * Default constructor
+         */
+        AlignmentMetrics() : numReads(0), numCorrReads(0), numCorrByMEM(0),
+                numSubstitutions(0) {}
+
+        /**
+         * Update the statistics
+         * @param corrected True if (part of) the read was corrected
+         * @param corrByMEM True if MEM procedure was used
+         * @param numSubstitutions_ Number of substitutions made to this read
+         */
+        void addObservation(bool corrected, bool corrByMEM,
+                            size_t numSubstitutions_) {
+                numReads++;
+                if (corrected)
+                        numCorrReads++;
+                if (corrByMEM)
+                        numCorrByMEM++;
+                numSubstitutions += numSubstitutions_;
+        }
+
+        /**
+         * Add other metrics (thread-safe)
+         * @param metrics Metrics to add
+         */
+        void addMetrics(const AlignmentMetrics& rhs);
+
+        /**
+         * Get the number of reads
+         * @return The number of reads
+         */
+        size_t getNumReads() const {
+                return numReads;
+        }
+
+        /**
+         * Get the number of corrected reads
+         * @return The number of corrected reads
+         */
+        size_t getNumCorrReads() const {
+                return numCorrReads;
+        }
+
+        /**
+         * Get the number of corrected reads using the MEM procedure
+         * @return The number of corrected reads using the MEM procedure
+         */
+        size_t getNumCorrByMEM() const {
+                return numCorrByMEM;
+        }
+
+        /**
+         * Get the number of substitutions made to the reads
+         * @return The number of substitutions made to the reads
+         */
+        size_t getNumSubstitutions() const {
+                return numSubstitutions;
+        }
+
+        /**
+         * Output statistics to the stdout
+         */
+        void printStatistics() const;
+};
 
 // ============================================================================
 // SEED CLASS
@@ -138,8 +220,9 @@ private:
         /**
          * Correct a specific read record
          * @param record Record to correct (input/output)
+         * @param metric Alignment metric to update (input/output)
          */
-        void correctRead(ReadRecord& record);
+        void correctRead(ReadRecord& record, AlignmentMetrics& metric);
 
         /**
          * Correct the records in one chunk
@@ -192,10 +275,6 @@ private:
                         const std::vector<Seed>& seeds);
 
 public:
-        size_t numOfReads;
-        size_t numOfCorrectedReads;
-        size_t numOfChangesInReads;
-        size_t numOfCorrectedByMem;
         /**
          * Default constructor
          * @param dbg_ Reference to the De Bruijn graph
@@ -204,14 +283,15 @@ public:
         ReadCorrectionJan(const DBGraph& dbg_, const Settings& settings_,
                           const sparseSA& sa_, const std::vector<long>& startpos_) :
                           dbg(dbg_), settings(settings_),
-                          alignment(100, 2, 1, -1, -3), sa(sa_), startpos(startpos_),numOfReads(0),numOfCorrectedReads(0),
-                          numOfChangesInReads(0),numOfCorrectedByMem(0) {}
+                          alignment(100, 2, 1, -1, -3), sa(sa_), startpos(startpos_) {}
 
         /**
          * Correct the records in one chunk
          * @param readChunk Chunk of records to correct
+         * @param metric Alignment metric to update
          */
-        void correctChunk(std::vector<ReadRecord>& readChunk);
+        void correctChunk(std::vector<ReadRecord>& readChunk,
+                          AlignmentMetrics& metric);
 };
 
 // ============================================================================
@@ -226,18 +306,17 @@ private:
         sparseSA *sa;
         std::string reference;
         std::vector<long> startpos;
-        atomic< size_t> numOfAllReads;
-        atomic< size_t> numOfAllCorrectedReads;
-        atomic< size_t> numOfAllChangesInReads;
-        atomic< size_t> numOfAllCorrectedByMem;
+
         void initEssaMEM();
 
         /**
          * Entry routine for worker thread
          * @param myID Unique threadID
          * @param libaries Library container with libraries to be corrected
+         * @param metrics Alignment metrics accross threads
          */
-        void workerThread(size_t myID, LibraryContainer& libraries);
+        void workerThread(size_t myID, LibraryContainer& libraries,
+                          AlignmentMetrics& metrics);
 
 public:
         /**

--- a/src/readcorrection.h
+++ b/src/readcorrection.h
@@ -65,7 +65,7 @@ public:
                 numReads++;
                 if (corrected)
                         numCorrReads++;
-                if (corrByMEM)
+                if (corrected && corrByMEM)
                         numCorrByMEM++;
                 numSubstitutions += numSubstitutions_;
         }

--- a/src/readcorrection.h
+++ b/src/readcorrection.h
@@ -192,6 +192,10 @@ private:
                         const std::vector<Seed>& seeds);
 
 public:
+        size_t numOfReads;
+        size_t numOfCorrectedReads;
+        size_t numOfChangesInReads;
+        size_t numOfCorrectedByMem;
         /**
          * Default constructor
          * @param dbg_ Reference to the De Bruijn graph
@@ -200,7 +204,8 @@ public:
         ReadCorrectionJan(const DBGraph& dbg_, const Settings& settings_,
                           const sparseSA& sa_, const std::vector<long>& startpos_) :
                           dbg(dbg_), settings(settings_),
-                          alignment(100, 2, 1, -1, -3), sa(sa_), startpos(startpos_) {}
+                          alignment(100, 2, 1, -1, -3), sa(sa_), startpos(startpos_),numOfReads(0),numOfCorrectedReads(0),
+                          numOfChangesInReads(0),numOfCorrectedByMem(0) {}
 
         /**
          * Correct the records in one chunk
@@ -221,7 +226,10 @@ private:
         sparseSA *sa;
         std::string reference;
         std::vector<long> startpos;
-
+        atomic< size_t> numOfAllReads;
+        atomic< size_t> numOfAllCorrectedReads;
+        atomic< size_t> numOfAllChangesInReads;
+        atomic< size_t> numOfAllCorrectedByMem;
         void initEssaMEM();
 
         /**

--- a/src/util.h
+++ b/src/util.h
@@ -100,6 +100,16 @@ public:
          * @return The probability p(k)
          */
         static double poissonPDF(unsigned int k, double mu);
+
+        /**
+         * Compute the percentage of two size_t numbers
+         * @param nom Nominator
+         * @param den Denominator
+         * @return The percentage
+         */
+        static double toPercentage(size_t nom, size_t den) {
+                return 100.0 * double(nom) / double(den);
+        }
 };
 
 #endif


### PR DESCRIPTION
This modifications enables Brownie to display number of changes  in the entire data set to correct the reads. Indels are ignored and only substitutions took into consideration.  It also shows percentages of reads which have been corrected and the number of reads which are corrected by EssaMEM. 
