### PR TITLE
Fix bug in cytoscape output

### DIFF
--- a/src/solutioncomp.cpp
+++ b/src/solutioncomp.cpp
@@ -125,7 +125,7 @@ void DBGraph::writeCytoscapeGraph(const std::string& filename,
 
                 ofs << *it << "\t" << node.getMarginalLength() << "\t"
                     << thisTrueMult << "\t" << "0" << "\t"
-                    << node.getAvgKmerCov() << "\t"
+                    << node.getAvgKmerCov()
                     << "\t" << double(node.getReadStartCov()/node.getMarginalLength())
                     << "\t" << node.getSequence() << "\n";
         }


### PR DESCRIPTION
There should be only 1 tab between columns, there were 2.
